### PR TITLE
fix: Remove state overwrite for plaintext field.

### DIFF
--- a/planetscale/database_branch_password_resource.go
+++ b/planetscale/database_branch_password_resource.go
@@ -2,6 +2,7 @@ package planetscale
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -165,7 +166,6 @@ func (r *databaseBranchPasswordResource) Read(ctx context.Context, req resource.
 
 	// Overwrite items with refreshed state
 	state.Username = types.StringValue(databaseBranchPassword.Username)
-	state.Plaintext = types.StringValue(databaseBranchPassword.PlainText)
 
 	// Set refreshed state
 	diags = resp.State.Set(ctx, &state)


### PR DESCRIPTION
This fixes the bug reported in #12 in which subsequent runs after creation would result in the property plaintext having the value null, since the Planetscale SDK returns null for this field after the password resource has been created.