### PR TITLE
Adds support for GCP regions on `database_resource` and `database_branch_resource`

### DIFF
--- a/docs/resources/database.md
+++ b/docs/resources/database.md
@@ -23,7 +23,7 @@ A Planetscale database. This resource will create a new database in your Planets
 ### Optional
 
 - `notes` (String) Notes about the database. These are only visible to you and other members of the organization.
-- `region` (String) The region where the database will be created. If not specified, the default region for the organization will be used. Values supported are: us-east, us-west, eu-west, ap-southeast, ap-south, ap-northeast, eu-central, aws-ap-southeast-2, aws-sa-east-1, aws-sa-east-2. For more information on regions, please see here: https://planetscale.com/docs/reference/region.
+- `region` (String) The region where the database will be created. If not specified, the default region for the organization will be used. Currently, following regions are supported: ap-northeast, ap-south, ap-southeast, aws-ap-southeast-2, eu-central, eu-west, aws-eu-west-2, aws-sa-east-1, us-east, aws-us-east-2, us-west, gcp-us-central1, gcp-us-east4, gcp-northamerica-northeast1, gcp-asia-northeast3. For more information on regions, please see here: https://planetscale.com/docs/concepts/regions.
 
 ### Read-Only
 

--- a/docs/resources/database_branch.md
+++ b/docs/resources/database_branch.md
@@ -25,7 +25,7 @@ A database branch resource. This resource allows you to create and manage databa
 
 - `backup_id` (String) The ID of the backup to create the database branch from. If not specified, the database's default branch will be used.
 - `parent_branch` (String) The name of the parent branch to create the database branch from. If not specified, the database's default branch will be used.
-- `region` (String) The region to create the database branch in. If not specified, the organization's default region will be used. Values supported are: us-east, us-west, eu-west, ap-southeast, ap-south, ap-northeast, eu-central, aws-ap-southeast-2, aws-sa-east-1, aws-sa-east-2. For more information on regions, please see here: https://planetscale.com/docs/reference/region.
+- `region` (String) The region where the database will be created. If not specified, the default region for the organization will be used. Currently, following regions are supported: ap-northeast, ap-south, ap-southeast, aws-ap-southeast-2, eu-central, eu-west, aws-eu-west-2, aws-sa-east-1, us-east, aws-us-east-2, us-west, gcp-us-central1, gcp-us-east4, gcp-northamerica-northeast1, gcp-asia-northeast3. For more information on regions, please see here: https://planetscale.com/docs/concepts/regions.
 - `seed_data` (String) The name of the database branch to seed the new database branch with. If not specified, the database's default branch will be used.
 
 ### Read-Only

--- a/planetscale/database_branch_resource.go
+++ b/planetscale/database_branch_resource.go
@@ -69,22 +69,29 @@ func (r *databaseBranchResource) Schema(_ context.Context, _ resource.SchemaRequ
 			},
 			"region": schema.StringAttribute{
 				Optional: true,
-				Description: "The region to create the database branch in. If not specified, the organization's default" +
-					" region will be used. Values supported are: us-east, us-west, eu-west, ap-southeast, ap-south," +
-					" ap-northeast, eu-central, aws-ap-southeast-2, aws-sa-east-1, aws-sa-east-2." +
-					" For more information on regions, please see here: https://planetscale.com/docs/reference/region.",
+				Description: "The region where the database will be created. If not specified, the default region" +
+					" for the organization will be used. Currently, following regions are supported: " +
+					"ap-northeast, ap-south, ap-southeast, aws-ap-southeast-2, eu-central, eu-west, aws-eu-west-2, " +
+					"aws-sa-east-1, us-east, aws-us-east-2, us-west, gcp-us-central1, gcp-us-east4, " +
+					"gcp-northamerica-northeast1, gcp-asia-northeast3. For more information on regions, " +
+					"please see here: https://planetscale.com/docs/concepts/regions.",
 				Validators: []validator.String{
 					stringvalidator.OneOf(
-						"us-east",
-						"us-west",
-						"eu-west",
-						"ap-southeast",
-						"ap-south",
 						"ap-northeast",
-						"eu-central",
+						"ap-south",
+						"ap-southeast",
 						"aws-ap-southeast-2",
+						"eu-central",
+						"eu-west",
+						"aws-eu-west-2",
 						"aws-sa-east-1",
-						"aws-sa-east-2",
+						"us-east",
+						"aws-us-east-2",
+						"us-west",
+						"gcp-us-central1",
+						"gcp-us-east4",
+						"gcp-northamerica-northeast1",
+						"gcp-asia-northeast3",
 					),
 				},
 			},

--- a/planetscale/database_resource.go
+++ b/planetscale/database_resource.go
@@ -66,21 +66,28 @@ func (r *databaseResource) Schema(_ context.Context, _ resource.SchemaRequest, r
 			"region": schema.StringAttribute{
 				Optional: true,
 				Description: "The region where the database will be created. If not specified, the default region" +
-					" for the organization will be used. Values supported are: us-east, us-west, eu-west, ap-southeast," +
-					" ap-south, ap-northeast, eu-central, aws-ap-southeast-2, aws-sa-east-1, aws-sa-east-2. For more information" +
-					" on regions, please see here: https://planetscale.com/docs/reference/region.",
+					" for the organization will be used. Currently, following regions are supported: " +
+					"ap-northeast, ap-south, ap-southeast, aws-ap-southeast-2, eu-central, eu-west, aws-eu-west-2, " +
+					"aws-sa-east-1, us-east, aws-us-east-2, us-west, gcp-us-central1, gcp-us-east4, " +
+					"gcp-northamerica-northeast1, gcp-asia-northeast3. For more information on regions, " +
+					"please see here: https://planetscale.com/docs/concepts/regions.",
 				Validators: []validator.String{
 					stringvalidator.OneOf(
-						"us-east",
-						"us-west",
-						"eu-west",
-						"ap-southeast",
-						"ap-south",
 						"ap-northeast",
-						"eu-central",
+						"ap-south",
+						"ap-southeast",
 						"aws-ap-southeast-2",
+						"eu-central",
+						"eu-west",
+						"aws-eu-west-2",
 						"aws-sa-east-1",
-						"aws-sa-east-2",
+						"us-east",
+						"aws-us-east-2",
+						"us-west",
+						"gcp-us-central1",
+						"gcp-us-east4",
+						"gcp-northamerica-northeast1",
+						"gcp-asia-northeast3",
 					),
 				},
 			},


### PR DESCRIPTION
## Motivation

- Cannot create Planetscale database on GCP regions. (See: #17)

## Changes made

- [feat: add GCP regions support for database resource](https://github.com/01Joseph-Hwang10/terraform-provider-planetscale/commit/81b7806c29d13b3ebd107b910ce8384b9468d686)
- [feat: add GCP regions support for database branch resource](https://github.com/01Joseph-Hwang10/terraform-provider-planetscale/commit/fa28a9fa7e13fbfe1194550c901f7af07a8563f6)
- [docs: generate markdown docs for updated region prop description](https://github.com/01Joseph-Hwang10/terraform-provider-planetscale/commit/44cc97ee3f07e2d0c8b089b9d5e0545da7654977)

## Test Scope / Change Impact

- Should able to use both [AWS and GCP regions supported by Planetscale](https://planetscale.com/docs/concepts/regions) for `database_resource` and `database_branch_resource` 

## Test

> [!NOTE]\
> I tested changes described above with the terraform code below. The code below successfully configured databases and branches given the service token has right permissions to perform the operations.

`test.tf`
```tf
terraform {
  required_providers {
    planetscale = {
      # Source locally built binary for testing
      source  = "registry.local/koslib/planetscale"
      version = "~> 0.5"
    }
  }
}

provider "planetscale" {
  service_token_id = "<service-token-id>"
  service_token    = "<service-token>"
}

locals {
  organization = "joseph95501"
}

resource "planetscale_database" "database_on_aws" {
  name         = "test-db-on-aws"
  organization = local.organization
  region       = "us-east"
}

resource "planetscale_database_branch" "aws_db_branch" {
  database     = planetscale_database.database_on_aws.name
  name         = "dev"
  organization = local.organization
  region       = "us-east"
}

resource "planetscale_database" "database_on_gcp" {
  name         = "test-db-on-gcp"
  organization = local.organization
  region       = "gcp-asia-northeast3"
}

resource "planetscale_database_branch" "gcp_db_branch" {
  database     = planetscale_database.database_on_gcp.name
  name         = "dev"
  organization = local.organization
  region       = "gcp-asia-northeast3"
}
```
